### PR TITLE
add hydratable in compilerOptions

### DIFF
--- a/rollup.config-ssr.js
+++ b/rollup.config-ssr.js
@@ -21,7 +21,7 @@ export default {
   },
   plugins: [
     svelte({
-			compilerOptions: { generate: "ssr" },
+			compilerOptions: { generate: "ssr", hydratable: true },
 			emitCss: false,
       preprocess
     }),


### PR DESCRIPTION
Add hydratable to prevent head duplication when scripts run in <svelte:head>
Sapper PR with solve: https://github.com/sveltejs/sapper/issues/1124#issuecomment-678727230

A few live story examples:
https://pudding.cool/2021/04/solo/ (3x duplication)
https://pudding.cool/2021/06/same-gender-lyrics/ (2x duplication)