### PR TITLE
Add Meta Tag in Head

### DIFF
--- a/src/app.html
+++ b/src/app.html
@@ -2,6 +2,8 @@
 <html lang="en">
 
 <head>
+	<meta charset="utf-8" />
+	<meta name="viewport" content="width=device-width, initial-scale=1" />
 	%svelte.head%
 </head>
 


### PR DESCRIPTION
Added `<meta name="viewport" content="width=device-width, initial-scale=1" />` in `app.html`. 

This was causing pages in my website to not be responsive and is also included by default normally in most Sveltekit starters.

To see the issue, check the [responsiveness of this page](https://61d1e372dae8f30008c775df--thedivtagguy2.netlify.app/projects/srishti-archive/) compared to [this one](https://61d50a1e4818ce0007968595--thedivtagguy2.netlify.app/projects/srishti-archive/)



