### PR TITLE
Improve screen reader UX by aria-hiding the Chevron icons

### DIFF
--- a/src/components/helpers/migrate/Tap.svelte
+++ b/src/components/helpers/migrate/Tap.svelte
@@ -52,9 +52,9 @@
 			{#if visibleArrows.includes(dir)}
 				<span style="font-size: {arrowSize};">
 					{#if dir === "left"}
-						<ChevronLeft color={arrowStroke} strokeWidth={arrowStrokeWidth} />
+						<ChevronLeft aria-hidden="true" color={arrowStroke} strokeWidth={arrowStrokeWidth} />
 					{:else if dir === "right"}
-						<ChevronRight color={arrowStroke} strokeWidth={arrowStrokeWidth} />
+						<ChevronRight aria-hidden="true" color={arrowStroke} strokeWidth={arrowStrokeWidth} />
 					{/if}
 				</span>
 			{/if}


### PR DESCRIPTION
To reproduce:

1. Begin using Mac VoiceOver
2. Navigate to a button containing the Chevron
3. Note that the screen reader announces a button group with an image in it. But this image contains no relevant information for a screen reader.
4. By aria-hiding the icon, the screen reader now announces a regular button, no group

### Currently:
<img width="716" alt="button, group" src="https://github.com/user-attachments/assets/802fa679-2bd3-4f70-b6fa-ff1194d0286d">

If you descend into the group:

<img width="714" alt="selected chevron" src="https://github.com/user-attachments/assets/719f8945-e08e-41f8-a2c9-1c45c0de65f9">

### With this PR:
<img width="765" alt="aria-hidden chevron" src="https://github.com/user-attachments/assets/67edb3cd-ab34-4982-b0ee-d83a1236e77b">

